### PR TITLE
UG Instructors: Add Create Session Link for Students

### DIFF
--- a/ug/instructors.md
+++ b/ug/instructors.md
@@ -56,3 +56,11 @@ The repositories used for initial bug reporting will be created automatically by
   This must be a public repo with write access given to students.
 * A repo to hold bugs for tutors to moderate e.g., `module-org/pe-moderation`<br>
   This can be a private repo with write access given to tutors.
+
+#### Creating a session link for students
+
+A list of profiles can be modified in `profiles.json` in the repository `client_data`. 
+
+To create a session link, add the name of the session after this url: `https://catcher-org.github.io/CATcher/?session=`. This profile name must correspond exactly to the `profileName` value in `profiles.json`. 
+
+Students can access the session link to apply the corresponding session to the field if the profile name is valid from the list of profiles. Students can then click the Submit button to enter the session specified without selecting from the dropdown.

--- a/ug/instructors.md
+++ b/ug/instructors.md
@@ -87,4 +87,4 @@ To create a session link, instructors will need to encode this url `https://catc
 
 For example, for profile name `"CS2103/T Alpha Test"`, the url will be `https://catcher-org.github.io/CATcher/?session=CS2103%2FT%20Alpha%20Test`.
 
-If the profile name is valid, students can access the link to select the corresponding session automatically. Students can then click the Submit button to enter the intended session without selecting from the dropdown.
+If the profile name is valid, students can access the link to select the corresponding session automatically. Students can then click the **Submit** button to enter the intended session without selecting from the dropdown.

--- a/ug/instructors.md
+++ b/ug/instructors.md
@@ -12,7 +12,7 @@ This document is only relevant for instructors who has plays the admin role of a
 
 --------------------------------------------------------------------------------------------
 
-## Configuring the org
+## Configuring the organization
 
 The host Github organization must have the following settings:
 1. Ensure `Base Permissions` is set to `None`.
@@ -27,11 +27,20 @@ The host Github organization must have the following settings:
 
 --------------------------------------------------------------------------------------------
 
-## Setting up repos
+## Setting up repositories
 
 For each phase, users with write access will be able to upload files (e.g. screenshots, .txt files, etc...) onto the repository's `/file` folder. These files are used in conjunction with issue description and comments in a form of a link. As for images, the actual image will be displayed.
 
-#### Settings repo:
+Instructors will have to create the following repositories:
+* Settings repository
+* Profile repository
+* Repositories for holding processed bug reports
+
+The following repositories will be created automatically by CATcher:
+* Repositories for collecting initial bug reports
+
+
+#### Settings repository
 * Suggested name: `module-org/pe`
 * The name of this repository must be stated in the application during login. This repository must contain a **`data.csv`** and a **`settings.json`** file.
 * **`data.csv`**
@@ -46,6 +55,18 @@ For each phase, users with write access will be able to upload files (e.g. scree
     2. The name of the repository that each phase is to utilize.
   * Example https://github.com/CATcher-org/public_data/blob/master/settings.json
 
+#### Profile repository
+* Suggested name: `client_data`
+
+This repository must contain a **`profiles.json`** file.
+
+* **`profiles.jsonn`**
+  * Must contain the following information:
+  1. Profile Name
+  2. Name of Settings repository
+  * Example https://github.com/CATcher-org/client_data/blob/master/profiles.json
+
+
 #### Repositories for collecting initial bug reports
 
 The repositories used for initial bug reporting will be created automatically by CATcher, in the tester's own GitHub account e.g., `user/pe`. The same repo will be used during the tester-response phase.
@@ -56,11 +77,12 @@ The repositories used for initial bug reporting will be created automatically by
   This must be a public repo with write access given to students.
 * A repo to hold bugs for tutors to moderate e.g., `module-org/pe-moderation`<br>
   This can be a private repo with write access given to tutors.
+  
 
-#### Creating a session link for students
+## Creating a session link for students
 
-A list of profiles can be modified in `profiles.json` in the repository `client_data`. 
+A list of profiles can be modified in the Profile repository. 
 
-To create a session link, add the name of the session after this url: `https://catcher-org.github.io/CATcher/?session=`. This profile name must correspond exactly to the `profileName` value in `profiles.json`. 
+To create a session link, add the name of the session after this url: `https://catcher-org.github.io/CATcher/?session=`. This profile name must correspond exactly to the profile name in Profile repository. 
 
 Students can access the session link to apply the corresponding session to the field if the profile name is valid from the list of profiles. Students can then click the Submit button to enter the session specified without selecting from the dropdown.

--- a/ug/instructors.md
+++ b/ug/instructors.md
@@ -88,3 +88,4 @@ To create a session link, instructors will need to encode this url `https://catc
 For example, for profile name `"CS2103/T Alpha Test"`, the url will be `https://catcher-org.github.io/CATcher/?session=CS2103%2FT%20Alpha%20Test`.
 
 If the profile name is valid, students can access the link to select the corresponding session automatically. Students can then click the **Submit** button to enter the intended session without selecting from the dropdown.
+

--- a/ug/instructors.md
+++ b/ug/instructors.md
@@ -87,4 +87,4 @@ To create a session link, instructors will need to encode this url `https://catc
 
 For example, for profile name `"CS2103/T Alpha Test"`, the url will be `https://catcher-org.github.io/CATcher/?session=CS2103%2FT%20Alpha%20Test`.
 
-Students can access the session link to apply the corresponding session to the field if the profile name is valid from the list of profiles. Students can then click the Submit button to enter the session specified without selecting from the dropdown.
+If the profile name is valid, students can access the link to select the corresponding session automatically. Students can then click the Submit button to enter the intended session without selecting from the dropdown.

--- a/ug/instructors.md
+++ b/ug/instructors.md
@@ -60,10 +60,10 @@ The following repositories will be created automatically by CATcher:
 
 This repository must contain a **`profiles.json`** file.
 
-* **`profiles.jsonn`**
+* **`profiles.json`**
   * Must contain the following information:
-  1. Profile Name
-  2. Name of Settings repository
+    1. Profile Name
+    2. Name of Settings repository
   * Example https://github.com/CATcher-org/client_data/blob/master/profiles.json
 
 
@@ -83,6 +83,8 @@ The repositories used for initial bug reporting will be created automatically by
 
 A list of profiles can be modified in the Profile repository. 
 
-To create a session link, add the name of the session after this url: `https://catcher-org.github.io/CATcher/?session=`. This profile name must correspond exactly to the profile name in Profile repository. 
+To create a session link, instructors will need to encode this url `https://catcher-org.github.io/CATcher/?session=PROFILE_NAME` where `PROFILE_NAME` is the profile name of the session. This profile name must correspond exactly to the profile name in the Profile repository. 
+
+For example, for profile name `"CS2103/T Alpha Test"`, the url will be `https://catcher-org.github.io/CATcher/?session=CS2103%2FT%20Alpha%20Test`.
 
 Students can access the session link to apply the corresponding session to the field if the profile name is valid from the list of profiles. Students can then click the Submit button to enter the session specified without selecting from the dropdown.


### PR DESCRIPTION
### Summary:
Adds documentation for CATcher-org/CATcher#778

### Changes Made:
* Add documentation for session link for students
* Add documentation for profile repository

### Proposed Commit Message:
```
UG Instructors: Profile repository and
Create Session Link for Students

Instructors are unclear on how to use the session link feature 
of CATcher.

Let's 
* add the format to create the session link to the UG
* advise how to modify valid profiles in the UG

```
