### PR TITLE
move dev commands to relevant sections

### DIFF
--- a/dg/project-management.md
+++ b/dg/project-management.md
@@ -12,6 +12,22 @@ This page contains info relevant to project management activities, typically don
 
 -------------------------------------------------------------------------------------
 
+## Dev commands
+
+Given below are different commands you can run to build the application in different operating systems.
+
+|Command|Description|
+|--|--|
+|`npm run build`| Build the app. Your built files are in the /dist folder. |
+|`npm run build:prod`| Build the app with Angular aot. Your built files are in the /dist folder. |
+|`npm run electron:local`| Builds your application and start electron
+|`npm run electron:linux`| Builds your application and creates an app consumable on linux system |
+|`npm run electron:windows`| On a Windows OS, builds your application and creates an app consumable in windows 32/64 bit systems |
+|`npm run electron:mac`|  On a MAC OS, builds your application and generates a `.app` file of your application that can be run on Mac |
+|`npm run deploy:web`| Will deploy the app onto the Github's `gh-pages` branch. <br/> Prerequisites:<br/> 1. Add Environment variable of `GH_TOKEN=<Github Personal Access Token>` with the permission of `repo`. <br/>2. `build:prod:web` command's `--base-href` argument in `package.json` must have the following format `https://<OrgName or Username>.github.io/CATcher/`. <br/> 3. If you are deploying outside of CATcher-org then it would be necessary to create a new OAuth application and change the `clientId` in `environment.prod.ts` <br/> 4. If you are deploying outside of CATcher-org, you would also need to deploy your own instance of proxy server using [gatekeeper](https://github.com/CATcher-org/gatekeeper) and change the appropriate variables in `environment.prod.ts`. |
+
+-------------------------------------------------------------------------------------
+
 ## Automated release
 
 Follow these steps to release a new version of CATcher using a GitHub Actions' workflow.

--- a/dg/setting-up.md
+++ b/dg/setting-up.md
@@ -28,24 +28,12 @@ This section guides you through the steps required to set up your computer for d
 
 ## Dev commands
 
-Given below are different commands you can run to build the application in different operating systems.
+Given below are different commands you can use to run the app locally.
 
 |Command|Description|
 |--|--|
 |`npm start`| Start the app from Electron in development mode. |
 |`npm run ng:serve:web`| Start the app from the browser in development mode. |
-|`npm run build`| Build the app. Your built files are in the /dist folder. |
-|`npm run build:prod`| Build the app with Angular aot. Your built files are in the /dist folder. |
-|`npm run electron:local`| Builds your application and start electron
-|`npm run electron:linux`| Builds your application and creates an app consumable on linux system |
-|`npm run electron:windows`| On a Windows OS, builds your application and creates an app consumable in windows 32/64 bit systems |
-|`npm run electron:mac`|  On a MAC OS, builds your application and generates a `.app` file of your application that can be run on Mac |
-|`npm run deploy:web`| Will deploy the app onto the Github's `gh-pages` branch. <br/> Prerequisites:<br/> 1. Add Environment variable of `GH_TOKEN=<Github Personal Access Token>` with the permission of `repo`. <br/>2. `build:prod:web` command's `--base-href` argument in `package.json` must have the following format `https://<OrgName or Username>.github.io/CATcher/`. <br/> 3. If you are deploying outside of CATcher-org then it would be necessary to create a new OAuth application and change the `clientId` in `environment.prod.ts` <br/> 4. If you are deploying outside of CATcher-org, you would also need to deploy your own instance of proxy server using [gatekeeper](https://github.com/CATcher-org/gatekeeper) and change the appropriate variables in `environment.prod.ts`. |
- | `npm run lint` | Runs the linter (TSLint) |
- | `npm run test` | Runs the tests           |
- | `npm run test -- "--code-coverage"` | Runs the tests and generates code coverage report under `tests/coverage` folder |
-
-We have a GitHub Actions' workflow that can perform some of the tasks above with a single-click.
 
 -----------------------------------------------------------------------------------
 

--- a/dg/testing.md
+++ b/dg/testing.md
@@ -12,6 +12,17 @@ This page contains information useful for testing of CATcher.
 
 -------------------------------------------------------------------------------------
 
+## Dev commands
+
+Given below are different commands you can use to run the tests.
+
+|Command|Description|
+|--|--|
+ | `npm run lint` | Runs the linter (TSLint) |
+ | `npm run test` | Runs the tests           |
+ | `npm run test -- "--code-coverage"` | Runs the tests and generates code coverage report under `tests/coverage` folder |
+
+-------------------------------------------------------------------------------------
 ## Setting up custom CATcher sessions
 
 Sometimes, it may be useful to create and use your own custom CATcher session for manual testing, instead of using the default session on `CATcher-org` that is shared among the CATcher developers. 


### PR DESCRIPTION
### Summary:
Fixes https://github.com/CATcher-org/CATcher/issues/781

### Changes Made:
* Move the dev commands to the relevant sections

### Proposed Commit Message:
```
Move developer commands to relevant sections

Currently, the Setting up section of our developers' guide has a large
table of commands that are used in various development tasks 
(running tests, building the app, running the linter, etc), which 
might be confusing to newcomers.

Let's move these developer commands to their relevant sections to
reduce such confusion.
```
