### PR TITLE
Update documentation on parsing format

### DIFF
--- a/dg/user-workflow.md
+++ b/dg/user-workflow.md
@@ -181,7 +181,7 @@ Add a comment to the original issue in `tester/repo-name`, in the following form
 **Reason for disagreement:**
 [replace this with your reason]
 
--------------------
+<catcher-end-of-segment>
 ```
 Example:
 
@@ -199,7 +199,7 @@ Team chose `Rejected`.
 **Reason for disagreement:**
 [replace this with your reason]
 
--------------------
+<catcher-end-of-segment>
 ## :question: Issue severity
 
 Team chose `Low`.
@@ -211,7 +211,7 @@ Originally `High`.
 **Reason for disagreement:**
 [replace this with your reason]
 
--------------------
+<catcher-end-of-segment>
 ## :question: Issue type
 
 Team chose `DocumentationBug`.
@@ -223,7 +223,7 @@ Originally `FunctionalityBug`.
 **Reason for disagreement:**
 [replace this with your reason]
 
--------------------
+<catcher-end-of-segment>
 ```
 </panel>
 
@@ -256,7 +256,7 @@ Originally `FunctionalityBug`.
 **Reason for disagreement:**
 It's a bug, not a typo.
 
--------------------
+<catcher-end-of-segment>
 ```
 </panel>
 


### PR DESCRIPTION
### Summary:
When https://github.com/CATcher-org/CATcher/pull/997 is merged, we should update the documentation to match the changes as well

### Changes Made:

- Replace `-------------------` to `<catcher-end-of-segment>`

### Proposed Commit Message:
```
Update documentation on parsing format

Let's update the documentation to reflect changes made in CATcher.
```
