### PR TITLE
Add `<hr>` to all `<catcher-end-of-segment>`

### DIFF
--- a/dg/user-workflow.md
+++ b/dg/user-workflow.md
@@ -181,7 +181,7 @@ Add a comment to the original issue in `tester/repo-name`, in the following form
 **Reason for disagreement:**
 [replace this with your reason]
 
-<catcher-end-of-segment>
+<catcher-end-of-segment><hr>
 ```
 Example:
 
@@ -199,7 +199,7 @@ Team chose `Rejected`.
 **Reason for disagreement:**
 [replace this with your reason]
 
-<catcher-end-of-segment>
+<catcher-end-of-segment><hr>
 ## :question: Issue severity
 
 Team chose `Low`.
@@ -211,7 +211,7 @@ Originally `High`.
 **Reason for disagreement:**
 [replace this with your reason]
 
-<catcher-end-of-segment>
+<catcher-end-of-segment><hr>
 ## :question: Issue type
 
 Team chose `DocumentationBug`.
@@ -223,7 +223,7 @@ Originally `FunctionalityBug`.
 **Reason for disagreement:**
 [replace this with your reason]
 
-<catcher-end-of-segment>
+<catcher-end-of-segment><hr>
 ```
 </panel>
 
@@ -256,7 +256,7 @@ Originally `FunctionalityBug`.
 **Reason for disagreement:**
 It's a bug, not a typo.
 
-<catcher-end-of-segment>
+<catcher-end-of-segment><hr>
 ```
 </panel>
 


### PR DESCRIPTION
### Summary:
Fixes CATcher-org/CATcher#1208

### Changes Made:
* Add `<hr>` to all `<catcher-end-of-segment>`

### Proposed Commit Message:
```
Add `<hr>` to all `<catcher-end-of-segment>`

Currently, the DG user workflow guide uses <catcher-end-of-segment> 
as the separator. It should be <catcher-end-of-segment><hr> as 
mentioned in https://github.com/CATcher-org/CATcher/pull/997

This has caused some confusion among new contributors. Let's update
the example comments in the developer guide.
```
