### PR TITLE
Update team disagreement example to match actual comments

### DIFF
--- a/dg/user-workflow.md
+++ b/dg/user-workflow.md
@@ -192,7 +192,7 @@ Description of team's response
 # Items for the Tester to Verify
 ## :question: Issue response
 
-Team chose `Rejected`.
+Team chose `response.Rejected`.
 
 - [ ] I disagree
 
@@ -202,9 +202,9 @@ Team chose `Rejected`.
 <catcher-end-of-segment><hr>
 ## :question: Issue severity
 
-Team chose `Low`.
+Team chose `[severity.Low]`.
 
-Originally `High`.
+Originally `[severity.High]`.
 
 - [ ] I disagree
 
@@ -214,9 +214,9 @@ Originally `High`.
 <catcher-end-of-segment><hr>
 ## :question: Issue type
 
-Team chose `DocumentationBug`.
+Team chose `[type.DocumentationBug]`.
 
-Originally `FunctionalityBug`.
+Originally `[type.FunctionalityBug]`.
 
 - [ ] I disagree
 
@@ -247,9 +247,9 @@ Example:
 ```
 ## :question: Issue type
 
-Team chose `DocumentationBug`.
+Team chose `[type.DocumentationBug]`.
 
-Originally `FunctionalityBug`.
+Originally `[type.FunctionalityBug]`.
 
 - [x] I disagree
 

--- a/dg/user-workflow.md
+++ b/dg/user-workflow.md
@@ -192,7 +192,7 @@ Description of team's response
 # Items for the Tester to Verify
 ## :question: Issue response
 
-Team chose `response.Rejected`.
+Team chose `[response.Rejected]`.
 
 - [ ] I disagree
 

--- a/dg/user-workflow.md
+++ b/dg/user-workflow.md
@@ -192,7 +192,7 @@ Description of team's response
 # Items for the Tester to Verify
 ## :question: Issue response
 
-Team chose `[response.Rejected]`.
+Team chose [`response.Rejected`].
 
 - [ ] I disagree
 
@@ -202,9 +202,9 @@ Team chose `[response.Rejected]`.
 <catcher-end-of-segment><hr>
 ## :question: Issue severity
 
-Team chose `[severity.Low]`.
+Team chose [`severity.Low`].
 
-Originally `[severity.High]`.
+Originally [`severity.High`].
 
 - [ ] I disagree
 
@@ -214,9 +214,9 @@ Originally `[severity.High]`.
 <catcher-end-of-segment><hr>
 ## :question: Issue type
 
-Team chose `[type.DocumentationBug]`.
+Team chose [`type.DocumentationBug`].
 
-Originally `[type.FunctionalityBug]`.
+Originally [`type.FunctionalityBug`].
 
 - [ ] I disagree
 
@@ -247,9 +247,9 @@ Example:
 ```
 ## :question: Issue type
 
-Team chose `[type.DocumentationBug]`.
+Team chose [`type.DocumentationBug`].
 
-Originally `[type.FunctionalityBug]`.
+Originally [`type.FunctionalityBug`].
 
 - [x] I disagree
 

--- a/dg/user-workflow.md
+++ b/dg/user-workflow.md
@@ -291,9 +291,9 @@ Example:
 ## :question: Issue type
 ### Team says:
 
-Team chose `DocumentationBug`.
+Team chose [`type.DocumentationBug`].
 
-Originally `FunctionalityBug`.
+Originally [`type.FunctionalityBug`].
 
 ### Tester says:
 I think it a functionality bug.


### PR DESCRIPTION
### Summary:
The examples of the team disagreements with the tester, e.g.
```
**Reason for disagreement:**
[replace this with your reason]

<catcher-end-of-segment><hr>
## :question: Issue severity

Team chose `Low`.

Originally `High`.
```
are different from what's actually being used, which in the above example should be
```
**Reason for disagreement:**
[replace this with your reason]

<catcher-end-of-segment><hr>
## :question: Issue severity

Team chose [`severity.Low`].

Originally [`severity.High`].
```

See https://github.com/luminousleek/pe/issues/10, https://github.com/luminousleek/pe/issues/7, https://github.com/luminousleek/pe/issues/11 or the issues in your own pe repos for examples.

### Changes Made:
* Update disagreement example to format that is actually being used

### Proposed Commit Message:
```
The disagreement examples in the documentation is not the same as what
is actually being used, and what is actually being parsed by CATcher

Let's update the UG to match what's in the actual comments.
```
